### PR TITLE
Add encoder/decoder with simple string based definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ var encoded = abi.encode(tokenAbi, "balanceOf(uint256 address)", [ "0x0000000000
 var decoded = abi.decode(tokenAbi, "balanceOf(uint256 address)", data)
 ```
 
+#### Simple encoding and decoding
+
+```js
+var abi = require('ethereumjs-abi')
+
+// returns the encoded binary (as a Buffer) data to be sent
+var encoded = abi.simpleEncode("balanceOf(address):(uint256)", "0x0000000000000000000000000000000000000000")
+
+// returns the decoded array of arguments
+var decoded = abi.simpleDecode("balanceOf(address):(uint256)", data)
+```
+
 #### Solidity *tightly packed* formats
 
 This library also supports creating Solidity's tightly packed data constructs, which are used together with ```sha3```, ```sha256``` and ```ripemd160``` to create hashes.

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,30 @@ function parseNumber (arg) {
   }
 }
 
+// someMethod(bytes,uint)
+// someMethod(bytes,uint):(boolean)
+function parseSignature (sig) {
+  var tmp = /^(\w+)\((.+)\)$/.exec(sig)
+  if (tmp.length !== 3) {
+    throw new Error('Invalid method signature')
+  }
+
+  var args = /^(.+)\):\((.+)$/.exec(tmp[2])
+
+  if (args !== null && args.length === 3) {
+    return {
+      method: tmp[1],
+      args: args[1].split(','),
+      retargs: args[2].split(',')
+    }
+  } else {
+    return {
+      method: tmp[1],
+      args: tmp[2].split(',')
+    }
+  }
+}
+
 // Encodes a single item (can be dynamic array)
 // @returns: Buffer
 function encodeSingle (type, arg) {
@@ -282,6 +306,29 @@ ABI.rawEncodeResponse = function (types, args) {
 
 ABI.encode = function (abiDefinition, request, args) {
   throw new Error('Not implemented')
+}
+
+ABI.simpleEncode = function (method) {
+  var args = Array.prototype.slice.call(arguments).slice(1)
+  var sig = parseSignature(method)
+
+  // FIXME: validate/convert arguments
+  if (args.length !== sig.args.length) {
+    throw new Error('Argument count mismatch')
+  }
+
+  return ABI.rawEncode(sig.method, sig.args, args)
+}
+
+ABI.simpleDecode = function (method, data) {
+  var sig = parseSignature(method)
+
+  // FIXME: validate/convert arguments
+  if (!sig.retargs) {
+    throw new Error('No return values in method')
+  }
+
+  return ABI.rawDecode(sig.method, sig.args, sig.retargs, data)
 }
 
 ABI.rawDecode = function (name, intypes, outtypes, data) {


### PR DESCRIPTION
I like it (as described in #2), but not sure it should be included.

Sample code:
```js
var tmp

tmp = abi.simpleEncode('someMethod(bytes,uint):(bool)', '12341234234', 1234)
console.log('encoded method', tmp.toString('hex'))

tmp = abi.simpleDecode('someMethod(bytes,uint):(bool)', tmp)
console.log('decoded method', tmp)
```

Output:
```
encoded method 2e1b8e21000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000004d2000000000000000000000000000000000000000000000000000000000000000b3132333431323334323334000000000000000000000000000000000000000000
decoded method [ false ]
```

Works with arrays too `someMethod(bytes,uint[]):(bool)`:
```
encoded method d75ceaf400000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000b3132333431323334323334000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004d20000000000000000000000000000000000000000000000000000000000000001
```