### PR TITLE
Serpent overhaul: fix string types

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ var encoded = abi.rawEncode("balanceOf", abi.fromSerpent("i"), [ "0x000000000000
 var decoded = abi.rawDecode("balanceOf", abi.fromSerpent("i"), abi.fromSerpent("i"), data)
 ```
 
+Note: Serpent uses arbitary binary fields. If you want to store strings it is preferable to ensure it is stored as UTF8. `new Buffer(<string>, 'utf8')` can be used to ensure it is properly encoded.
+
 ## Contributing
 
 I am more than happy to receive improvements. Please send me a pull request or reach out on email or twitter.

--- a/README.md
+++ b/README.md
@@ -102,17 +102,15 @@ We provide two helpers to convert between these notations:
 
 Example usage:
 ```js
-abi.fromSerpent('s')    // [ 'string' ]
-abi.fromSerpent('b')    // [ 'bytes' ]
+abi.fromSerpent('s')    // [ 'bytes' ]
 abi.fromSerpent('i')    // [ 'int256' ]
 abi.fromSerpent('a')    // [ 'int256[]' ]
 abi.fromSerpent('b8')   // [ 'bytes8' ]
 abi.fromSerpent('b8i')  // [ 'bytes8', 'int256' ]
 
-abi.toSerpent([ 'string' ])            // 's'
+abi.toSerpent([ 'bytes' ])             // 's'
 abi.toSerpent([ 'int256' ])            // 'i'
 abi.toSerpent([ 'int256[]' ])          // 'a'
-abi.toSerpent([ 'bytes' ])             // 'b'
 abi.toSerpent([ 'bytes8' ])            // 'b8'
 abi.toSerpent([ 'bytes8', 'int256' ])  // 'b8i'
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -469,7 +469,9 @@ ABI.fromSerpent = function (sig) {
   var ret = []
   for (var i = 0; i < sig.length; i++) {
     var type = sig[i]
-    if (type === 's' || type === 'b') {
+    if (type === 's') {
+      ret.push('bytes')
+    } else if (type === 'b') {
       var tmp = 'bytes'
       var j = i + 1
       while ((j < sig.length) && isNumeric(sig[j])) {
@@ -493,7 +495,7 @@ ABI.toSerpent = function (types) {
   var ret = []
   for (var i = 0; i < types.length; i++) {
     var type = types[i]
-    if (type === 'bytes' || type === 'string') {
+    if (type === 'bytes') {
       ret.push('s')
     } else if (type.startsWith('bytes')) {
       ret.push('b' + parseTypeN(type))

--- a/test/index.js
+++ b/test/index.js
@@ -526,14 +526,13 @@ describe('solidity tight packing with small ints', function () {
 describe('converting from serpent types', function () {
   it('should equal', function () {
     assert.deepEqual(abi.fromSerpent('s'), [ 'bytes' ])
-    assert.deepEqual(abi.fromSerpent('b'), [ 'bytes' ])
     assert.deepEqual(abi.fromSerpent('i'), [ 'int256' ])
     assert.deepEqual(abi.fromSerpent('a'), [ 'int256[]' ])
     assert.deepEqual(abi.fromSerpent('b8'), [ 'bytes8' ])
     assert.deepEqual(abi.fromSerpent('b8i'), [ 'bytes8', 'int256' ])
     assert.deepEqual(abi.fromSerpent('b32'), [ 'bytes32' ])
     assert.deepEqual(abi.fromSerpent('b32i'), [ 'bytes32', 'int256' ])
-    assert.deepEqual(abi.fromSerpent('sbb8ib8a'), [ 'bytes', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ])
+    assert.deepEqual(abi.fromSerpent('sb8ib8a'), [ 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ])
     assert.throws(function () {
       abi.fromSerpent('i8')
     })
@@ -545,13 +544,12 @@ describe('converting from serpent types', function () {
 
 describe('converting to serpent types', function () {
   it('should equal', function () {
-    assert.equal(abi.toSerpent([ 'string' ]), 's')
+    assert.equal(abi.toSerpent([ 'bytes' ]), 's')
     assert.equal(abi.toSerpent([ 'int256' ]), 'i')
     assert.equal(abi.toSerpent([ 'int256[]' ]), 'a')
-    assert.equal(abi.toSerpent([ 'bytes' ]), 's')
     assert.equal(abi.toSerpent([ 'bytes8' ]), 'b8')
     assert.equal(abi.toSerpent([ 'bytes32' ]), 'b32')
-    assert.equal(abi.toSerpent([ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]), 'ssb8ib8a')
+    assert.equal(abi.toSerpent([ 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]), 'sb8ib8a')
     assert.throws(function () {
       abi.toSerpent('int8')
     })


### PR DESCRIPTION
As discussed with @tinybike, the `s` type in Serpent actually support arbitrary binary data. Mapping it to `string` here would cause it to be processed as UTF8 possibly resulting in invalid output.

With using `bytes` the caller must make sure to encode using UTF8 if needed by supplying the result of `new Buffer("hello", 'utf8')` as the input.

Fixes #15 #16.