### PR TITLE
support passing byte arrays to encoder

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,14 @@ function parseTypeArray (type) {
   }
 }
 
+function bytesToHex (bytes) {
+  for (var hex = [], i = 0; i < bytes.length; i++) {
+    hex.push((bytes[i] >>> 4).toString(16))
+    hex.push((bytes[i] & 0xF).toString(16))
+  }
+  return hex.join('')
+}
+
 function parseNumber (arg) {
   var type = typeof arg
   if (type === 'string') {
@@ -71,6 +79,11 @@ function parseNumber (arg) {
   } else if (arg.toArray) {
     // assume this is a BN for the moment, replace with BN.isBN soon
     return arg
+  } else if (type === 'object' && !arg.toArray) {
+    // arg is byte array
+    var hexStr = bytesToHex(arg)
+    var hexBn = new BN(hexStr, 16)
+    return hexBn
   } else {
     throw new Error('Argument is not a number')
   }


### PR DESCRIPTION
The purpose here is to enable using solidity hex literals `hex:"00ff"` as arguments in browser-solidity. You can try it at [http://cdetrio.github.io/browser-solidity](http://cdetrio.github.io/browser-solidity).

This works in conjunction with [dirty-json-hex](https://github.com/cdetrio/dirty-json-hex), which browser-solidity uses to parse solidity hex literals into byte arrays. The byte arrays are then passed to ethereumjs-abi encoder.

Alternatively, ethereumjs-abi could accept hex literals directly, even though they aren't valid json. Or it could accept both byte arrays and hex literals. thoughts?
