### PR TITLE
[issue 27] added support for arrays to ABI.solidityPack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -424,9 +424,11 @@ ABI.stringify = function (types, values) {
   return ret
 }
 
-ABI.solidityHexValue = function (type, value, bitsize=null) {
+ABI.solidityHexValue = function (type, value, bitsize) {
+  // pass in bitsize = null if use default bitsize
+  var size, num
   if (type.match('^[a-zA-Z0-9_]+(\\[[0-9]*\\])+$')) {
-    var sub_type = type.replace(/\[.*?\]/, "")
+    var sub_type = type.replace(/\[.*?\]/, '')
     var array_values = value.map(function (v) {
       return ABI.solidityHexValue(sub_type, v, 256)
     })
@@ -437,12 +439,12 @@ ABI.solidityHexValue = function (type, value, bitsize=null) {
     return new Buffer(value, 'utf8')
   } else if (type === 'bool') {
     bitsize = bitsize || 8
-    var padding = Array((bitsize) / 4).join("0")
-    return new Buffer(value ?  padding + "1" : padding + "0", 'hex')
+    var padding = Array((bitsize) / 4).join('0')
+    return new Buffer(value ? padding + '1' : padding + '0', 'hex')
   } else if (type === 'address') {
     var bytesize = 20
     if (bitsize) {
-        bytesize = bitsize / 8
+      bytesize = bitsize / 8
     }
     return utils.setLengthLeft(value, bytesize)
   } else if (type.startsWith('bytes')) {
@@ -489,17 +491,14 @@ ABI.solidityPack = function (types, values) {
     throw new Error('Number of types are not matching the values')
   }
 
-  var size, num
   var ret = []
 
   for (var i = 0; i < types.length; i++) {
-      var type = elementaryName(types[i])
-      var value = values[i]
-      var hexValue = ABI.solidityHexValue(type, value)
-      ret.push(ABI.solidityHexValue(type, value))
+    var type = elementaryName(types[i])
+    var value = values[i]
+    ret.push(ABI.solidityHexValue(type, value, null))
   }
 
-  console.log(ret)
   return Buffer.concat(ret)
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -424,6 +424,66 @@ ABI.stringify = function (types, values) {
   return ret
 }
 
+ABI.solidityHexValue = function (type, value, bitsize=null) {
+  if (type.match('^[a-zA-Z0-9_]+(\\[[0-9]*\\])+$')) {
+    var sub_type = type.replace(/\[.*?\]/, "")
+    var array_values = value.map(function (v) {
+      return ABI.solidityHexValue(sub_type, v, 256)
+    })
+    return Buffer.concat(array_values)
+  } else if (type === 'bytes') {
+    return value
+  } else if (type === 'string') {
+    return new Buffer(value, 'utf8')
+  } else if (type === 'bool') {
+    bitsize = bitsize || 8
+    var padding = Array((bitsize) / 4).join("0")
+    return new Buffer(value ?  padding + "1" : padding + "0", 'hex')
+  } else if (type === 'address') {
+    var bytesize = 20
+    if (bitsize) {
+        bytesize = bitsize / 8
+    }
+    return utils.setLengthLeft(value, bytesize)
+  } else if (type.startsWith('bytes')) {
+    size = parseTypeN(type)
+    if (size < 1 || size > 32) {
+      throw new Error('Invalid bytes<N> width: ' + size)
+    }
+
+    return utils.setLengthRight(value, size)
+  } else if (type.startsWith('uint')) {
+    size = parseTypeN(type)
+    if ((size % 8) || (size < 8) || (size > 256)) {
+      throw new Error('Invalid uint<N> width: ' + size)
+    }
+
+    num = parseNumber(value)
+    if (num.bitLength() > size) {
+      throw new Error('Supplied uint exceeds width: ' + size + ' vs ' + num.bitLength())
+    }
+
+    bitsize = bitsize || size
+    return num.toArrayLike(Buffer, 'be', bitsize / 8)
+  } else if (type.startsWith('int')) {
+    size = parseTypeN(type)
+    if ((size % 8) || (size < 8) || (size > 256)) {
+      throw new Error('Invalid int<N> width: ' + size)
+    }
+
+    num = parseNumber(value)
+    if (num.bitLength() > size) {
+      throw new Error('Supplied int exceeds width: ' + size + ' vs ' + num.bitLength())
+    }
+
+    bitsize = bitsize || size
+    return num.toTwos(size).toArrayLike(Buffer, 'be', bitsize / 8)
+  } else {
+    // FIXME: support all other types
+    throw new Error('Unsupported or invalid type: ' + type)
+  }
+}
+
 ABI.solidityPack = function (types, values) {
   if (types.length !== values.length) {
     throw new Error('Number of types are not matching the values')
@@ -433,54 +493,13 @@ ABI.solidityPack = function (types, values) {
   var ret = []
 
   for (var i = 0; i < types.length; i++) {
-    var type = elementaryName(types[i])
-    var value = values[i]
-
-    if (type === 'bytes') {
-      ret.push(value)
-    } else if (type === 'string') {
-      ret.push(new Buffer(value, 'utf8'))
-    } else if (type === 'bool') {
-      ret.push(new Buffer(value ? '01' : '00', 'hex'))
-    } else if (type === 'address') {
-      ret.push(utils.setLengthLeft(value, 20))
-    } else if (type.startsWith('bytes')) {
-      size = parseTypeN(type)
-      if (size < 1 || size > 32) {
-        throw new Error('Invalid bytes<N> width: ' + size)
-      }
-
-      ret.push(utils.setLengthRight(value, size))
-    } else if (type.startsWith('uint')) {
-      size = parseTypeN(type)
-      if ((size % 8) || (size < 8) || (size > 256)) {
-        throw new Error('Invalid uint<N> width: ' + size)
-      }
-
-      num = parseNumber(value)
-      if (num.bitLength() > size) {
-        throw new Error('Supplied uint exceeds width: ' + size + ' vs ' + num.bitLength())
-      }
-
-      ret.push(num.toArrayLike(Buffer, 'be', size / 8))
-    } else if (type.startsWith('int')) {
-      size = parseTypeN(type)
-      if ((size % 8) || (size < 8) || (size > 256)) {
-        throw new Error('Invalid int<N> width: ' + size)
-      }
-
-      num = parseNumber(value)
-      if (num.bitLength() > size) {
-        throw new Error('Supplied int exceeds width: ' + size + ' vs ' + num.bitLength())
-      }
-
-      ret.push(num.toTwos(size).toArrayLike(Buffer, 'be', size / 8))
-    } else {
-      // FIXME: support all other types
-      throw new Error('Unsupported or invalid type: ' + type)
-    }
+      var type = elementaryName(types[i])
+      var value = values[i]
+      var hexValue = ABI.solidityHexValue(type, value)
+      ret.push(ABI.solidityHexValue(type, value))
   }
 
+  console.log(ret)
   return Buffer.concat(ret)
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -501,6 +501,31 @@ describe('solidity tight packing multiple arguments', function () {
   })
 })
 
+describe('solidity tight packing arrays', function () {
+  it('should equal', function () {
+    var a = abi.solidityPack(
+      [ 'uint32[]' ],
+      [ [ 8, 9 ] ]
+    )
+    var b = '00000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000009'
+    assert.equal(a.toString('hex'), b.toString('hex'))
+
+    a = abi.solidityPack(
+      [ 'bool[][]' ],
+      [ [[true, false], [false, true]] ]
+    )
+    b = '0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001'
+    assert.equal(a.toString('hex'), b.toString('hex'))
+
+    a = abi.solidityPack(
+      [ 'address[]' ],
+      [ [new BN('43989fb883ba8111221e89123897538475893837', 16)] ]
+    )
+    b = '00000000000000000000000043989fb883ba8111221e89123897538475893837'
+    assert.equal(a.toString('hex'), b.toString('hex'))
+  })
+})
+
 describe('solidity tight packing sha3', function () {
   it('should equal', function () {
     var a = abi.soliditySHA3(


### PR DESCRIPTION
See [Issue 27](https://github.com/ethereumjs/ethereumjs-abi/issues/27)

Added support for arrays by recursively calling `solidityHexValue` and by coercing values of arrays to be padded to 256bit. The padding to 256bit happens to values of arrays when passed to keccak256 in Solidity. This is not obvious from the documentation.

`solidityHexValue` was factored out of `solidityPack` as a function to handle each type/value. Did this to be able to call it recursively.

Also added some passing tests.