### PR TITLE
Fix the rawDecode to utils toBuffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -359,7 +359,7 @@ ABI.rawEncode = function (types, values) {
 
 ABI.rawDecode = function (types, data) {
   var ret = []
-  data = new Buffer(data)
+  data = utils.toBuffer(data)
   var offset = 0
   for (var i in types) {
     var type = elementaryName(types[i])


### PR DESCRIPTION
This caused me a heap of problems decoding an output for Parity, and I imagine it's likely to help others down the road.