### PR TITLE
Replace problematic for..in loops with C-style loops

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -353,7 +353,7 @@ ABI.rawEncode = function (types, values) {
     }
   })
 
-  for (var i in types) {
+  for (var i = 0; i < types.length; i++) {
     var type = elementaryName(types[i])
     var value = values[i]
     var cur = encodeSingle(type, value)
@@ -375,7 +375,7 @@ ABI.rawDecode = function (types, data) {
   var ret = []
   data = new Buffer(data)
   var offset = 0
-  for (var i in types) {
+  for (var i = 0; i < types.length; i++) {
     var type = elementaryName(types[i])
     var parsed = parseType(type, data, offset)
     var decoded = decodeSingle(parsed, data, offset)


### PR DESCRIPTION
Because `for..in` loops are designed to iterate over the properties of Objects, they access enumerable properties up the prototype chain. Thus if the caller has extended Array.prototype, those new functions will be enumerated along with the contents of the array. This will cause ethereumjs-abi to break in the places I've changed to C-style loops.

More info on for..in loops [here](https://stackoverflow.com/a/5263872).