### PR TITLE
Fixup in parseSignature(...) for functions with no args

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ function parseNumber (arg) {
 // someMethod(bytes,uint)
 // someMethod(bytes,uint):(boolean)
 function parseSignature (sig) {
-  var tmp = /^(\w+)\((.+)\)$/.exec(sig)
+  var tmp = /^(\w+)\((.*)\)$/.exec(sig)
   if (tmp.length !== 3) {
     throw new Error('Invalid method signature')
   }
@@ -92,9 +92,14 @@ function parseSignature (sig) {
       retargs: args[2].split(',')
     }
   } else {
+    var params = tmp[2].split(',')
+    if(params.length === 1 && params[0] === '') {
+      //Special (possibly naive) fixup for functions that take no arguments.
+      params = []
+    }
     return {
       method: tmp[1],
-      args: tmp[2].split(',')
+      args: params
     }
   }
 }


### PR DESCRIPTION
Two things required to make this work:
 * Fixed the first regex to deal with tight braces
 * Slightly naive 'special case' fixup prior to return if there were no args. I don't really like special cases like this but on the plus side, it makes the fix very self-contained - everything else based on regexs, split(), and array comparison continues to work so it's very low-risk

Testing evidence:
*** In a plain node console:
> var abi = require('ethereumjs-abi')
undefined
//First test we didn’t break the existing functionality!
> abi.simpleEncode("inc(uint)", "0x13").toString("hex")
‘812600df0000000000000000000000000000000000000000000000000000000000000013'
//Now test the new one
> abi.simpleEncode("meaningOfLife()").toString("hex")
'5353455a'
> .exit

*** Then with a running network and a contract deployed with a 'meaningOfLife()' function exported:
root@77d32569caa0:/project/sawtooth-seth/contracts/examples/simple_intkey# seth contract call --wait jag_x9 46ae4ccf394274f606a3e0bb397ee9fb3ad90e06 5353455a
Enter Password to unlock jag_x9: 
Contract called
Transaction Receipt:  {
  "TransactionID": "ea5e92b0eab77bae858a632e0606989a600fe6563f2aceff9d6634b47137e0a169e10400915d3be1e4e2d8de0770f1f32dc916ee4296693e6ecb86c1193a0387",
  "GasUsed": 86,
  "ReturnValue": "000000000000000000000000000000000000000000000000000000000000002a"
}