### PR TITLE
Adding encoding aided by the JSON ABI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,30 +112,3 @@ var decoded = abi.rawDecode("balanceOf", abi.fromSerpent("i"), abi.fromSerpent("
 ```
 
 Note: Serpent uses arbitary binary fields. If you want to store strings it is preferable to ensure it is stored as UTF8. `new Buffer(<string>, 'utf8')` can be used to ensure it is properly encoded.
-
-## Contributing
-
-I am more than happy to receive improvements. Please send me a pull request or reach out on email or twitter.
-
-There is a lot missing, grep for *FIXME* in the source code to find inspiration.
-
-## License
-
-    Copyright (C) 2015 Alex Beregszaszi
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy of
-    this software and associated documentation files (the "Software"), to deal in
-    the Software without restriction, including without limitation the rights to
-    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-    the Software, and to permit persons to whom the Software is furnished to do so,
-    subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There are three methods of interest:
 - ```methodID``` to create a function signature
 - ```rawEncode``` to encode fields and
 - ```rawDecode``` to decode fields
+- ```Encode```   to create full ABI format 
 
 Example code:
 ```js
@@ -32,8 +33,17 @@ var decoded = abi.rawDecode([ "address" ], data)
 #### Encoding and decoding aided by the JSON ABI definition
 
 Planned for the future is supporting the JSON ABI definition:
-
 ```js
+var  abi = [{"constant":false,"inputs":[{"name":"val","type":"int256"}],"name":"setVal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"getVal","outputs":[{"name":"","type":"int256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
+
+var encoded = ABI.encode(abi,"setVal",[1234]);
+
+console.log(encoded.toString("hex"));
+
+Output :
+5362f8a200000000000000000000000000000000000000000000000000000000000004d2
+```js
+
 var abi = require('ethereumjs-abi')
 
 // need to have the ABI definition in JSON as per specification

--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# easy-abi
+# ethereumjs-abi
+
+[![NPM Package](https://img.shields.io/npm/v/ethereumjs-abi.svg?style=flat-square)](https://www.npmjs.org/package/ethereumjs-abi)
+[![Build Status](https://img.shields.io/travis/ethereumjs/ethereumjs-abi.svg?branch=master&style=flat-square)](https://travis-ci.org/ethereumjs/ethereumjs-abi)
+[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-abi.svg?style=flat-square)](https://coveralls.io/r/ethereumjs/ethereumjs-abi)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+[![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs-lib.svg?style=flat-square)](https://gitter.im/ethereum/ethereumjs-lib) or #ethereumjs on freenode
+
+
+Module implementing the [Ethereum ABI](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI) in Javascript. Can be used with RPC libraries for communication or with ethereumjs-vm to implement a fully fledged simulator.
 
 ## Usage
-#### Encoding and decoding aided by the JSON ABI definition
-```js
-var  abi = [{"constant":false,"inputs":[{"name":"val","type":"int256"}],"name":"setVal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"getVal","outputs":[{"name":"","type":"int256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
 
-var encoded = ABI.encode(abi,"setVal",[1234]);
-
-console.log(encoded.toString("hex"));
-
-Output :
-5362f8a200000000000000000000000000000000000000000000000000000000000004d2
-```
 #### Manual encoding and decoding
 
 There are three methods of interest:
 - ```methodID``` to create a function signature
 - ```rawEncode``` to encode fields and
 - ```rawDecode``` to decode fields
-- ```Encode```   to create full ABI format 
 
 Example code:
 ```js
@@ -31,6 +29,20 @@ var encoded = abi.rawEncode([ "address" ], [ "0x00000000000000000000000000000000
 var decoded = abi.rawDecode([ "address" ], data)
 ```
 
+#### Encoding and decoding aided by the JSON ABI definition
+
+Supporting the JSON ABI definition:
+
+```js
+var  abi = [{"constant":false,"inputs":[{"name":"val","type":"int256"}],"name":"setVal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"getVal","outputs":[{"name":"","type":"int256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
+
+var encoded = ABI.encode(abi,"setVal",[1234]);
+
+console.log(encoded.toString("hex"));
+
+Output :
+5362f8a200000000000000000000000000000000000000000000000000000000000004d2
+```
 
 #### Simple encoding and decoding
 
@@ -106,9 +118,36 @@ abi.toSerpent([ 'bytes8', 'int256' ])  // 'b8i'
 It is to be used in conjunction with ```rawEncode``` and ```rawDecode```:
 
 ```js
-var encoded = abi.rawEncode("balanceOf", abi.fromSerpent("i"), [ "0x0000000000000000000000000000000000000000" ])
+var encoded = abi.rawEncode(abi.fromSerpent("i"), [ "0x0000000000000000000000000000000000000000" ])
 
-var decoded = abi.rawDecode("balanceOf", abi.fromSerpent("i"), abi.fromSerpent("i"), data)
+var decoded = abi.rawDecode([...abi.fromSerpent("i"), ...abi.fromSerpent("i")], data)
 ```
 
 Note: Serpent uses arbitary binary fields. If you want to store strings it is preferable to ensure it is stored as UTF8. `new Buffer(<string>, 'utf8')` can be used to ensure it is properly encoded.
+
+## Contributing
+
+I am more than happy to receive improvements. Please send me a pull request or reach out on email or twitter.
+
+There is a lot missing, grep for *FIXME* in the source code to find inspiration.
+
+## License
+
+    Copyright (C) 2015 Alex Beregszaszi
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# ethereumjs-abi
-
-[![NPM Package](https://img.shields.io/npm/v/ethereumjs-abi.svg?style=flat-square)](https://www.npmjs.org/package/ethereumjs-abi)
-[![Build Status](https://img.shields.io/travis/ethereumjs/ethereumjs-abi.svg?branch=master&style=flat-square)](https://travis-ci.org/ethereumjs/ethereumjs-abi)
-[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-abi.svg?style=flat-square)](https://coveralls.io/r/ethereumjs/ethereumjs-abi)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
-[![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs-lib.svg?style=flat-square)](https://gitter.im/ethereum/ethereumjs-lib) or #ethereumjs on freenode
-
-
-Module implementing the [Ethereum ABI](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI) in Javascript. Can be used with RPC libraries for communication or with ethereumjs-vm to implement a fully fledged simulator.
+# easy-abi
 
 ## Usage
+#### Encoding and decoding aided by the JSON ABI definition
+```js
+var  abi = [{"constant":false,"inputs":[{"name":"val","type":"int256"}],"name":"setVal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"getVal","outputs":[{"name":"","type":"int256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
 
+var encoded = ABI.encode(abi,"setVal",[1234]);
+
+console.log(encoded.toString("hex"));
+
+Output :
+5362f8a200000000000000000000000000000000000000000000000000000000000004d2
+```
 #### Manual encoding and decoding
 
 There are three methods of interest:
@@ -30,29 +31,6 @@ var encoded = abi.rawEncode([ "address" ], [ "0x00000000000000000000000000000000
 var decoded = abi.rawDecode([ "address" ], data)
 ```
 
-#### Encoding and decoding aided by the JSON ABI definition
-
-Planned for the future is supporting the JSON ABI definition:
-```js
-var  abi = [{"constant":false,"inputs":[{"name":"val","type":"int256"}],"name":"setVal","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[],"name":"getVal","outputs":[{"name":"","type":"int256"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]
-
-var encoded = ABI.encode(abi,"setVal",[1234]);
-
-console.log(encoded.toString("hex"));
-
-Output :
-5362f8a200000000000000000000000000000000000000000000000000000000000004d2
-```js
-
-var abi = require('ethereumjs-abi')
-
-// need to have the ABI definition in JSON as per specification
-var tokenAbi = [{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"success","type":"bool"}],"type":"function"},{"inputs":[],"type":"constructor"}]
-
-var encoded = abi.encode(tokenAbi, "balanceOf(uint256 address)", [ "0x0000000000000000000000000000000000000000" ])
-
-var decoded = abi.decode(tokenAbi, "balanceOf(uint256 address)", data)
-```
 
 #### Simple encoding and decoding
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -337,21 +337,7 @@ ABI.rawEncode = function (types, values) {
   var output = []
   var data = []
 
-  var headLength = 0
-
-  types.forEach(function (type) {
-    if (isArray(type)) {
-      var size = parseTypeArray(type)
-
-      if (size !== 'dynamic') {
-        headLength += 32 * size
-      } else {
-        headLength += 32
-      }
-    } else {
-      headLength += 32
-    }
-  })
+  var headLength = 32 * types.length
 
   for (var i in types) {
     var type = elementaryName(types[i])
@@ -369,6 +355,48 @@ ABI.rawEncode = function (types, values) {
   }
 
   return Buffer.concat(output.concat(data))
+}
+
+// Encode a method/event with arguments
+// @types an array of string type names
+// @args  an array of the appropriate values
+ABI.encode = function (tokenAbi, name, values) {
+  var output = []
+  var data = []  
+  var types  = this.makeTypeList(tokenAbi,name);
+  output.push(this.methodID(name,types));
+  var headLength = 32 * types.length
+
+  for (var i in types) {
+    var type = elementaryName(types[i])
+    var value = values[i]
+    var cur = encodeSingle(type, value)
+
+    // Use the head/tail method for storing dynamic data
+    if (isDynamic(type)) {
+      output.push(encodeSingle('uint256', headLength))
+      data.push(cur)
+      headLength += cur.length
+    } else {
+      output.push(cur)
+    }
+  }
+
+  return Buffer.concat(output.concat(data))
+}
+
+ABI.makeTypeList = (abi , functionName)=>{
+    
+  let inputs = [];
+  abi.forEach(element => {
+    if(element.type === "function" && element.name === functionName){      
+      element.inputs.forEach(input =>{
+          inputs.push(input.type);
+      });
+    }
+  });
+
+  return inputs;
 }
 
 ABI.rawDecode = function (types, data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -337,9 +337,23 @@ ABI.rawEncode = function (types, values) {
   var output = []
   var data = []
 
-  var headLength = 32 * types.length
+  var headLength = 0
 
-  for (var i in types) {
+  types.forEach(function (type) {
+    if (isArray(type)) {
+      var size = parseTypeArray(type)
+
+      if (size !== 'dynamic') {
+        headLength += 32 * size
+      } else {
+        headLength += 32
+      }
+    } else {
+      headLength += 32
+    }
+  })
+
+  for (var i = 0; i < types.length; i++) {
     var type = elementaryName(types[i])
     var value = values[i]
     var cur = encodeSingle(type, value)
@@ -362,12 +376,12 @@ ABI.rawEncode = function (types, values) {
 // @args  an array of the appropriate values
 ABI.encode = function (tokenAbi, name, values) {
   var output = []
-  var data = []  
-  var types  = this.makeTypeList(tokenAbi,name);
-  output.push(this.methodID(name,types));
+  var data = []
+  var types = this.makeTypeList(tokenAbi, name)
+  output.push(this.methodID(name, types))
   var headLength = 32 * types.length
 
-  for (var i = 0; i < types.length; i++) {
+  for (var i in types) {
     var type = elementaryName(types[i])
     var value = values[i]
     var cur = encodeSingle(type, value)
@@ -385,18 +399,17 @@ ABI.encode = function (tokenAbi, name, values) {
   return Buffer.concat(output.concat(data))
 }
 
-ABI.makeTypeList = (abi , functionName)=>{
-    
-  let inputs = [];
+ABI.makeTypeList = (abi, functionName) => {
+  let inputs = []
   abi.forEach(element => {
-    if(element.type === "function" && element.name === functionName){      
-      element.inputs.forEach(input =>{
-          inputs.push(input.type);
-      });
+    if (element.type === 'function' && element.name === functionName) {
+      element.inputs.forEach(input => {
+        inputs.push(input.type)
+      })
     }
-  });
+  })
 
-  return inputs;
+  return inputs
 }
 
 ABI.rawDecode = function (types, data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -400,7 +400,7 @@ ABI.encode = function (tokenAbi, name, values) {
 }
 
 ABI.makeTypeList = (abi, functionName) => {
-  let inputs = []
+  var inputs = []
   abi.forEach(element => {
     if (element.type === 'function' && element.name === functionName) {
       element.inputs.forEach(input => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "easy-abi",
-  "version": "0.0.1",
+  "name": "ethereumjs-abi",
+  "version": "0.6.6",
   "description": "Decoder and encoder for the Ethereum ABI",
   "main": "index.js",
   "dependencies": {
@@ -22,18 +22,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pouladzade/easy-abi.git"
+    "url": "git+https://github.com/axic/ethereumjs-abi.git"
   },
   "keywords": [
     "ethereum",
     "ABI"
   ],
-  "author": "Ahmad Pouladzadeh <pouladzade@gmail.com>",
+  "author": "Alex Beregszaszi <alex@rtfs.hu>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pouladzade/easy-abi/issues"
+    "url": "https://github.com/axic/ethereumjs-abi/issues"
   },
-  "homepage": "https://github.com/pouladzade/easy-abi",
+  "homepage": "https://github.com/axic/ethereumjs-abi",
   "standard": {
     "globals": [
       "describe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ethereumjs-abi",
-  "version": "0.6.5",
+  "name": "easy-abi",
+  "version": "0.0.1",
   "description": "Decoder and encoder for the Ethereum ABI",
   "main": "index.js",
   "dependencies": {
@@ -22,18 +22,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/axic/ethereumjs-abi.git"
+    "url": "git+https://github.com/pouladzade/easy-abi.git"
   },
   "keywords": [
     "ethereum",
     "ABI"
   ],
-  "author": "Alex Beregszaszi <alex@rtfs.hu>",
+  "author": "Ahmad Pouladzadeh <pouladzade@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/axic/ethereumjs-abi/issues"
+    "url": "https://github.com/pouladzade/easy-abi/issues"
   },
-  "homepage": "https://github.com/axic/ethereumjs-abi",
+  "homepage": "https://github.com/pouladzade/easy-abi",
   "standard": {
     "globals": [
       "describe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-abi",
-  "version": "0.6.6",
+  "version": "0.6.5",
   "description": "Decoder and encoder for the Ethereum ABI",
   "main": "index.js",
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -787,3 +787,215 @@ describe('decoding (uint[][3], uint)', function () {
     assert.equal(a[0][2][1].toString(10), 6)
   })
 })
+
+describe('encoding using ABI Json (int256)', function () {
+  it('should work', function () {
+    var json_abi = [
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'val',
+            'type': 'int256'
+          }
+        ],
+        'name': 'setVal',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [],
+        'name': 'getVal',
+        'outputs': [
+          {
+            'name': '',
+            'type': 'int256'
+          }
+        ],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      }
+    ]
+
+    var encoded = abi.encode(json_abi, 'setVal', [new BN('123456789123456789', 10)])
+    assert.equal(encoded.toString('hex'), '5362f8a200000000000000000000000000000000000000000000000001b69b4bacd05f15')
+  })
+})
+
+describe('encoding using ABI Json (string)', function () {
+  it('should work', function () {
+    var json_abi = [
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'a',
+            'type': 'int256'
+          }
+        ],
+        'name': 'setA',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'a',
+            'type': 'int256'
+          },
+          {
+            'name': 'b',
+            'type': 'string'
+          },
+          {
+            'name': 'c',
+            'type': 'bytes8'
+          }
+        ],
+        'name': 'setABC',
+        'outputs': [
+          {
+            'name': '',
+            'type': 'int256'
+          },
+          {
+            'name': '',
+            'type': 'string'
+          },
+          {
+            'name': '',
+            'type': 'bytes8'
+          }
+        ],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'b',
+            'type': 'string'
+          }
+        ],
+        'name': 'setB',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'c',
+            'type': 'bytes8'
+          }
+        ],
+        'name': 'setC',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      }
+    ]
+
+    var encoded = abi.encode(json_abi, 'setB', ['salam halet khoobe'])
+
+    assert.equal(encoded.toString('hex'), 'b5e7bc600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001273616c616d2068616c6574206b686f6f62650000000000000000000000000000')
+  })
+})
+
+describe('encoding using ABI Json (int256,string,bytes8)', function () {
+  it('should work', function () {
+    var json_abi = [
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'a',
+            'type': 'int256'
+          }
+        ],
+        'name': 'setA',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'a',
+            'type': 'int256'
+          },
+          {
+            'name': 'b',
+            'type': 'string'
+          },
+          {
+            'name': 'c',
+            'type': 'bytes8'
+          }
+        ],
+        'name': 'setABC',
+        'outputs': [
+          {
+            'name': '',
+            'type': 'int256'
+          },
+          {
+            'name': '',
+            'type': 'string'
+          },
+          {
+            'name': '',
+            'type': 'bytes8'
+          }
+        ],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'b',
+            'type': 'string'
+          }
+        ],
+        'name': 'setB',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      },
+      {
+        'constant': false,
+        'inputs': [
+          {
+            'name': 'c',
+            'type': 'bytes8'
+          }
+        ],
+        'name': 'setC',
+        'outputs': [],
+        'payable': false,
+        'stateMutability': 'nonpayable',
+        'type': 'function'
+      }
+    ]
+    var encoded = abi.encode(json_abi, 'setABC', [12, 'salam', [1, 2, 3, 4, 5, 6, 7, 8]])
+    assert.equal(encoded.toString('hex'), 'f77a13e1000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000600102030405060708000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000573616c616d000000000000000000000000000000000000000000000000000000')
+  })
+})


### PR DESCRIPTION
1-Adding encoding aided by the JSON ABI (` encode(json_abi, function_name, parameter_list)` )
2- Updating the readme
3- Adding tests regarding the new encoding method

**Example**:
```js
var json_abi = [{"constant":false,"inputs":[{"name":"a","type":"int256"}],"name":"setA","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"},{"name":"b","type":"string"},{"name":"c","type":"bytes8"}],"name":"setABC","outputs":[{"name":"","type":"int256"},{"name":"","type":"string"},{"name":"","type":"bytes8"}],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"b","type":"string"}],"name":"setB","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"name":"c","type":"bytes8"}],"name":"setC","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]

var encoded = abi.encode(json_abi, 'setABC', [12, 'salam', [1, 2, 3, 4, 5, 6, 7, 8]])
console.log(encoded.toString("hex"))
```
Output:
```js
f77a13e1000000000000000000000000000000000000000000000000000000000000000c00000000000000000000000000000000000000000000000000000000000000600102030405060708000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000573616c616d000000000000000000000000000000000000000000000000000000
```